### PR TITLE
Add docs folder and trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,9 @@
 
 # Slab
 
-Slab is an immediate mode GUI toolkit for the Love 2D framework. This library is designed to
-allow users to easily add this library to their existing Love 2D projects and quickly create
-tools to enable them to iterate on their ideas quickly. The user should be able to utilize this
-library with minimal integration steps and is completely written in Lua and utilizes
-the Love 2D API. No compiled binaries are required and the user will have access to the source
-so that they may make adjustments that meet the needs of their own projects and tools. Refer
-to main.lua and SlabTest.lua for example usage of this library.
+Slab is an immediate mode GUI toolkit for the Love 2D framework. This library is designed to allow users to easily add user interfaces to their Love 2D projects and quickly create tools for rapid iteration. It is completely written in Lua and relies only on the Love 2D API.
 
-### Usage
-
-Integrating this library into existing projects is very simple.
-
-```lua
-local Slab = require 'Slab'
-
-function love.load(args)
-	love.graphics.setBackgroundColor(0.4, 0.88, 1.0)
-	Slab.Initialize(args)
-end
-
-function love.update(dt)
-	Slab.Update(dt)
-  
-	Slab.BeginWindow('MyFirstWindow', {Title = "My First Window"})
-	Slab.Text("Hello World")
-	Slab.EndWindow()
-end
-
-function love.draw()
-	Slab.Draw()
-end
-```
-![](https://github.com/coding-jackalope/Slab/wiki/Images/Slab_HelloWorld.png)
-
-For more detailed information on usage of this library, refer to the [Wiki](https://github.com/coding-jackalope/Slab/wiki).
+Full documentation has moved to the [docs](docs/index.md) directory. The docs contain a quick start guide and additional examples.
 
 [LOVE forum](https://love2d.org/forums/viewtopic.php?t=86410)
 
@@ -45,8 +13,8 @@ For more detailed information on usage of this library, refer to the [Wiki](http
 Slab is licensed under the MIT license. Please see the LICENSE file for more information.
 
 ### Credits
-* [coding-jackalope](https://github.com/coding-jackalope) original developer of this library.
-* [Dear ImGui](https://github.com/ocornut/imgui) project built by Omar Cornut and various contributors. This project was the inspiration for building an Immediate Mode GUI for Love2D specifically. If anyone is building a game or application in C++, I highly recommend using this library and its rich toolset to speed up development.
-* [Kenney.nl](https://kenney.nl/) and the [Tango Desktop Project](https://opengameart.org/content/tango-desktop-icons) for providing icons used in this project.
-* [lovefs](https://github.com/linux-man/lovefs) provides some FFI code for the filesystem.
-* [luapower/fs](https://github.com/luapower/fs) provides cross platform FFI code for the filesystem.
+- [coding-jackalope](https://github.com/coding-jackalope) original developer of this library.
+- [Dear ImGui](https://github.com/ocornut/imgui) project built by Omar Cornut and various contributors.
+- [Kenney.nl](https://kenney.nl/) and the [Tango Desktop Project](https://opengameart.org/content/tango-desktop-icons) for providing icons used in this project.
+- [lovefs](https://github.com/linux-man/lovefs) provides some FFI code for the filesystem.
+- [luapower/fs](https://github.com/luapower/fs) provides cross platform FFI code for the filesystem.

--- a/TODO.md
+++ b/TODO.md
@@ -3,13 +3,13 @@
 Below is a proposed list of tasks for migrating documentation to a GitHub Pages powered wiki and for upcoming refactors.
 
 ## GitHub Pages Wiki Tasks
-1. **Create docs directory**
+1. **Create docs directory** *(done)*
    - Add `docs/index.md` with project overview, quick start, and link to examples.
    - Configure the repository to use the `docs/` folder for GitHub Pages in repository settings.
-2. **Migrate existing README content**
+2. **Migrate existing README content** *(in progress)*
    - Split longer sections (usage, license, credits) into dedicated pages.
    - Keep a trimmed README that links to the wiki.
-3. **Write API reference**
+3. **Write API reference** *(partial)*
    - Document each module and function from `API.lua`.
    - Include code snippets and images from `SlabTest.lua`.
 4. **Add tutorials and examples**

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+Documentation for the public API is a work in progress. For now consult the comments in [API.lua](../API.lua) and the examples in [SlabTest.lua](../SlabTest.lua).

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -1,0 +1,7 @@
+# Credits
+
+- [coding-jackalope](https://github.com/coding-jackalope) original developer of this library.
+- [Dear ImGui](https://github.com/ocornut/imgui) inspired the creation of an immediate mode GUI for Love2D.
+- [Kenney.nl](https://kenney.nl/) and the [Tango Desktop Project](https://opengameart.org/content/tango-desktop-icons) provided icons.
+- [lovefs](https://github.com/linux-man/lovefs) supplies some FFI filesystem code.
+- [luapower/fs](https://github.com/luapower/fs) provides cross-platform FFI filesystem code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Slab Documentation
+
+Welcome to the Slab documentation site. This site provides an overview of the project, a quick start guide and links to examples.
+
+## Overview
+Slab is an immediate mode GUI toolkit for the Love 2D framework written entirely in Lua. It allows you to quickly build tools and interfaces for your Love 2D projects without the need for compiled binaries.
+
+## Quick Start
+See [quick_start.md](quick_start.md) for a minimal example of integrating Slab into a project. The examples directory also contains ready-to-run demos.
+
+## Examples
+Check out the example usage in [SlabTest.lua](../SlabTest.lua) and the small demo in [main.lua](../main.lua).

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,0 +1,29 @@
+# Quick Start
+
+Add Slab to your Love 2D project with:
+```lua
+local Slab = require 'Slab'
+```
+In `love.load` initialise the library and set a background colour:
+```lua
+function love.load(args)
+    love.graphics.setBackgroundColor(0.4, 0.88, 1.0)
+    Slab.Initialize(args)
+end
+```
+Create and render windows inside `love.update`:
+```lua
+function love.update(dt)
+    Slab.Update(dt)
+    Slab.BeginWindow('MyFirstWindow', {Title = 'My First Window'})
+    Slab.Text('Hello World')
+    Slab.EndWindow()
+end
+```
+Finally call `Slab.Draw()` from `love.draw`:
+```lua
+function love.draw()
+    Slab.Draw()
+end
+```
+See [main.lua](../main.lua) for a full demo.


### PR DESCRIPTION
## Summary
- start docs for GitHub pages with index, quick start and credits
- point README at new docs
- mark progress in TODO

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68732c832f308329b46a51b681be4aed